### PR TITLE
Search for libraries first from /usr/libexec/droid-hybris/system/lib/hw/

### DIFF
--- a/hardware.c
+++ b/hardware.c
@@ -30,6 +30,7 @@
 /** Base path of the hal modules */
 #define HAL_LIBRARY_PATH1 "/system/lib/hw"
 #define HAL_LIBRARY_PATH2 "/vendor/lib/hw"
+#define HAL_LIBRARY_PATH3 "/usr/libexec/droid-hybris/system/lib/hw"
 
 /**
  * There are a set of variant filename for modules. The form of the filename
@@ -148,6 +149,10 @@ int hw_get_module_by_class(const char *class_id, const char *inst,
                 continue;
             }
             snprintf(path, sizeof(path), "%s/%s.%s.so",
+                     HAL_LIBRARY_PATH3, name, prop);
+            if (access(path, R_OK) == 0) break;
+
+            snprintf(path, sizeof(path), "%s/%s.%s.so",
                      HAL_LIBRARY_PATH2, name, prop);
             if (access(path, R_OK) == 0) break;
 
@@ -155,6 +160,10 @@ int hw_get_module_by_class(const char *class_id, const char *inst,
                      HAL_LIBRARY_PATH1, name, prop);
             if (access(path, R_OK) == 0) break;
         } else {
+            snprintf(path, sizeof(path), "%s/%s.default.so",
+                     HAL_LIBRARY_PATH3, name);
+            if (access(path, R_OK) == 0) break;
+
             snprintf(path, sizeof(path), "%s/%s.default.so",
                      HAL_LIBRARY_PATH2, name);
             if (access(path, R_OK) == 0) break;


### PR DESCRIPTION
This allows loading patched hwcomposer and other libraries instead of replacing the libraries in /system. Needs https://github.com/libhybris/libhybris/pull/283 to work from /usr/libexec/droid-hybris/system/lib/.
